### PR TITLE
Fix formatting output for newer GCC.

### DIFF
--- a/src/cbuf.c
+++ b/src/cbuf.c
@@ -491,11 +491,11 @@ cbuf_dump(cbuf_t *cbuf, FILE *fp)
 {
 	unsigned per_row = 8;
 
-	fprintf(fp, "cbuf[%p]: pos %8u lim %8u cap %8u\n",
+	fprintf(fp, "cbuf[%p]: pos %8lu lim %8lu cap %8lu\n",
 	    cbuf, cbuf->cbuf_position, cbuf->cbuf_limit, cbuf->cbuf_capacity);
 
 	for (size_t i = 0; i < cbuf->cbuf_limit; i += per_row) {
-		fprintf(fp, "    %04x: ", i);
+		fprintf(fp, "    %04lx: ", i);
 		for (unsigned x = 0; x < per_row; x++) {
 			if (i + x >= cbuf->cbuf_limit) {
 				break;

--- a/src/cbuf.c
+++ b/src/cbuf.c
@@ -491,11 +491,11 @@ cbuf_dump(cbuf_t *cbuf, FILE *fp)
 {
 	unsigned per_row = 8;
 
-	fprintf(fp, "cbuf[%p]: pos %8lu lim %8lu cap %8lu\n",
+	fprintf(fp, "cbuf[%p]: pos %8zu lim %8zu cap %8zu\n",
 	    cbuf, cbuf->cbuf_position, cbuf->cbuf_limit, cbuf->cbuf_capacity);
 
 	for (size_t i = 0; i < cbuf->cbuf_limit; i += per_row) {
-		fprintf(fp, "    %04lx: ", i);
+		fprintf(fp, "    %04zx: ", i);
 		for (unsigned x = 0; x < per_row; x++) {
 			if (i + x >= cbuf->cbuf_limit) {
 				break;

--- a/src/cbufq.c
+++ b/src/cbufq.c
@@ -236,7 +236,7 @@ cbufq_dump(cbufq_t *cbufq, FILE *fp)
 {
 	unsigned i = 0;
 
-	fprintf(fp, "cbufq[%p]: count %8lu\n", cbufq, cbufq->cbufq_count);
+	fprintf(fp, "cbufq[%p]: count %8zu\n", cbufq, cbufq->cbufq_count);
 	for (cbuf_t *cbuf = list_head(&cbufq->cbufq_bufs); cbuf != NULL;
 	    cbuf = list_next(&cbufq->cbufq_bufs, cbuf)) {
 		fprintf(fp, "--- entry %8u ---\n", i++);

--- a/src/cbufq.c
+++ b/src/cbufq.c
@@ -236,7 +236,7 @@ cbufq_dump(cbufq_t *cbufq, FILE *fp)
 {
 	unsigned i = 0;
 
-	fprintf(fp, "cbufq[%p]: count %8u\n", cbufq, cbufq->cbufq_count);
+	fprintf(fp, "cbufq[%p]: count %8lu\n", cbufq, cbufq->cbufq_count);
 	for (cbuf_t *cbuf = list_head(&cbufq->cbufq_bufs); cbuf != NULL;
 	    cbuf = list_next(&cbufq->cbufq_bufs, cbuf)) {
 		fprintf(fp, "--- entry %8u ---\n", i++);


### PR DESCRIPTION
In support of ZK version upgrade to [binder](https://github.com/joyent/binder/pull/14).